### PR TITLE
Implement improvements based on feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,13 +176,13 @@
 
     // replaces mkdocs editing syntax either with a red strikethrough tag or a blue span tag
     function processEditingSyntax(content) {
-      const strikes = [...content.matchAll(/{--([\w ]+)--}/g)];
+      const strikes = [...content.matchAll(/{--([ -~]+?)--}/g)];
       for (let i = 0; i < strikes.length; i++) {
         const text = strikes[i][0];
         content = content.replace(text, `<s style="color: red">${strikes[i][1]}</s>`);
       }
 
-      const additions = [...content.matchAll(/{\+\+([\w ]+)\+\+}/g)];
+      const additions = [...content.matchAll(/{\+\+([ -~]+?)\+\+}/g)];
       for (let i = 0; i < additions.length; i++) {
         const text = additions[i][0];
         content = content.replace(text, `<span style="color: blue">${additions[i][1]}</span>`);

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown-light.min.css" integrity="sha512-X175XRJAO6PHAUi8AA7GP8uUF5Wiv+w9bOi64i02CHKDQBsO1yy0jLSKaUKg/NhRCDYBmOLQCfKaTaXiyZlLrw==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
 
   <style type="text/tailwindcss">
     body {
@@ -65,7 +66,7 @@
   <div class="mt-4 mb-8 w-full flex justify-center text-lg">
     <div class="w-[75vw]">
       <p class="font-bold text-2xl my-2">Clarifications:</p>
-      <md-block id="clarifications"></md-block>
+      <div class="markdown-body mx-1 my-0"><md-block id="clarifications"></md-block></div>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
     // start time and end times in 24hr format
     let start = '1300';
     let end = '1440';
+    const FONT_SCALING = '100%';
     const LOCAL_TESTING = false;
 
     const urlParams = new URLSearchParams(window.location.search);
@@ -192,6 +193,8 @@
     window.onload = () => {
       parseStartTime();
       showPassword();
+
+      document.getElementById('clarifications').style.fontSize = FONT_SCALING;
 
       document.getElementById('start').innerHTML = formatTime(start);
       document.getElementById('end').innerHTML = formatTime(end);

--- a/index.html
+++ b/index.html
@@ -174,16 +174,33 @@
       }, 1000);
     }
 
+    // replaces mkdocs editing syntax either with a red strikethrough tag or a blue span tag
+    function processEditingSyntax(content) {
+      const strikes = [...content.matchAll(/{--([\w ]+)--}/g)];
+      for (let i = 0; i < strikes.length; i++) {
+        const text = strikes[i][0];
+        content = content.replace(text, `<s style="color: red">${strikes[i][1]}</s>`);
+      }
+
+      const additions = [...content.matchAll(/{\+\+([\w ]+)\+\+}/g)];
+      for (let i = 0; i < additions.length; i++) {
+        const text = additions[i][0];
+        content = content.replace(text, `<span style="color: blue">${additions[i][1]}</span>`);
+      }
+
+      return content;
+    }
+
     function refreshClarifications() {
       if (LOCAL_TESTING) {
-        document.getElementById('clarifications').innerHTML = md.render(``);
+        document.getElementById('clarifications').innerHTML = processEditingSyntax(md.render(``));
         return;
       }
 
       fetch('clarifications.md', {cache: "no-cache"})
         .then(res => res.text())
         .then(data => {
-          document.getElementById('clarifications').innerHTML = md.render(data);
+          document.getElementById('clarifications').innerHTML = processEditingSyntax(md.render(data));
         })
         .catch(err => {
           console.log(err);

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown-light.min.css" integrity="sha512-X175XRJAO6PHAUi8AA7GP8uUF5Wiv+w9bOi64i02CHKDQBsO1yy0jLSKaUKg/NhRCDYBmOLQCfKaTaXiyZlLrw==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
 
   <style type="text/tailwindcss">
@@ -97,7 +97,7 @@
       }
     }
 
-        function updateClock() {
+    function updateClock() {
       const now = new Date();
       let hours = now.getHours();
       const minutes = now.getMinutes().toString().padStart(2, '0');

--- a/index.html
+++ b/index.html
@@ -14,27 +14,6 @@
     body {
       font-family: Roboto, sans-serif;
     }
-
-    @layer base {
-      h1 {
-        @apply text-3xl font-bold;
-      }
-      h2 {
-        @apply text-2xl font-semibold;
-      }
-      h3 {
-        @apply text-xl font-medium;
-      }
-      h4 {
-        @apply text-lg font-medium;
-      }
-      ul {
-        @apply list-disc ml-5;
-      }
-      ol {
-        @apply list-decimal ml-5;
-      }
-    }
   </style>
 </head>
 <body>
@@ -90,6 +69,13 @@
     </div>
   </div>
 
+  <script>
+    tailwind.config = {
+      corePlugins: {
+        preflight: false
+      }
+    }
+  </script>
   <script>
     // start time and end times in 24hr format
     let start = '1300';

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.tailwindcss.com"></script>
-  <script type="module" src="https://md-block.verou.me/md-block.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/markdown-it@14.1.0/dist/markdown-it.min.js"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -84,6 +84,7 @@
     const FONT_SCALING = '100%';
     const LOCAL_TESTING = false;
 
+    const md = window.markdownit();
     const urlParams = new URLSearchParams(window.location.search);
 
     function parseStartTime() {
@@ -175,18 +176,18 @@
 
     function refreshClarifications() {
       if (LOCAL_TESTING) {
-        document.getElementById('clarifications').mdContent = ``;
+        document.getElementById('clarifications').innerHTML = md.render(``);
         return;
       }
 
       fetch('clarifications.md', {cache: "no-cache"})
         .then(res => res.text())
         .then(data => {
-          document.getElementById('clarifications').mdContent = data;
+          document.getElementById('clarifications').innerHTML = md.render(data);
         })
         .catch(err => {
           console.log(err);
-          document.getElementById('clarifications').mdContent = 'Error loading, check console.';
+          document.getElementById('clarifications').innerHTML = 'Error loading, check console.';
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
 
   <div class="mt-4 mb-8 w-full flex justify-center text-lg">
     <div class="w-[75vw]">
-      <p class="font-bold text-2xl my-2">Clarifications:</p>
+      <span class="inline-block font-bold text-2xl border border-solid border-slate-800 rounded-lg px-1.5 py-0.5">Clarifications:</span>
       <div class="markdown-body mx-1 my-0"><md-block id="clarifications"></md-block></div>
     </div>
   </div>


### PR DESCRIPTION
The following improvements were proposed as follows, as well as my take on the pointers:

1. Bigger font by default, so that those sitting behind can read. Also having a fontsize toggle
    - This one can be easily resolved by zooming in the browser (with the browser zoom controls), and not strictly necessary. Also related to the page styles.
2. We commonly need to quote from the paper, so getting block quote > to work is very useful
    - The original page styles did not work nicely with this, resolved in this PR.
3. We need to support editing operation ~abc~ to strike out (in red) and to replace  it with +def+  (in blue).  This should work for text in backtick as well.
    - Exact implementation as above may lead to edge cases highlighting unexpectedly. After discussion, it was decided to adopt the mkdocs style for editing syntax.
4. General spacing/line height should be there — between two clarifications and between two paragraphs.
    - Also likely due to original page styles.
5. Supporting markdown fully

## Proposed Changes
As such, this PR incorporates the changes as described below:

- Remove original tailwind page styles, and use a custom stylesheet (github-markdown-css) for styling clarifications (should fix 2 and 4)
- Improve clarifications header to stand out slightly more
- Add static font scaling to change the size of clarifications text (use is not recommended, browser zoom is preferred)
- Use a different markdown library for more control (and hopefully resolves point 5 above)
- Add mkdocs/critic editing syntax for deletion using strikethrough with red text and additions in blue text

## Sample Output (rendered)
<img width="994" alt="Screenshot 2025-04-09 at 9 46 38 PM" src="https://github.com/user-attachments/assets/4cf63724-8241-4d1b-97bd-9801be4c4bf1" />
